### PR TITLE
Add domains environment configuration

### DIFF
--- a/terraform/domains/environment_domains/.terraform.lock.hcl
+++ b/terraform/domains/environment_domains/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.116.0"
+  constraints = "3.116.0"
+  hashes = [
+    "h1:BCR3NIorFSvGG3v/+JOiiw3VM4PkChLO4m84wzD9NDo=",
+    "zh:02b6606aff025fc2a962b3e568e000300abe959adac987183c24dac8eb057f4d",
+    "zh:2a23a8ce24ff9e885925ffee0c3ea7eadba7a702541d05869275778aa47bdea7",
+    "zh:57d10746384baeca4d5c56e88872727cdc150f437b8c5e14f0542127f7475e24",
+    "zh:59e3ebde1a2e1e094c671e179f231ead60684390dbf02d2b1b7fe67a228daa1a",
+    "zh:5f1f5c7d09efa2ee8ddf21bd9efbbf8286f6e90047556bef305c062fa0ac5880",
+    "zh:a40646aee3c9907276dab926e6123a8d70b1e56174836d4c59a9992034f88d70",
+    "zh:c21d40461bc5836cf56ad3d93d2fc47f61138574a55e972ad5ff1cb73bab66dc",
+    "zh:c56fb91a5ae66153ba0f737a26da1b3d4f88fdef7d41c63e06c5772d93b26953",
+    "zh:d1e60e85f51d12fc150aeab8e31d3f18f859c32f927f99deb5b74cb1e10087aa",
+    "zh:ed35e727e7d79e687cd3d148f52b442961ede286e7c5b4da1dcd9f0128009466",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f6d2a4e7c58f44e7d04a4a9c73f35ed452f412c97c85def68c4b52814cbe03ab",
+  ]
+}

--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -1,0 +1,23 @@
+{
+  "hosted_zone": {
+    "teach.education.gov.uk": {
+      "front_door_name": "s189p01-teach-dom-fd",
+      "resource_group_name": "s189p01-teach-dom-rg",
+      "domains": ["apex"],
+      "cached_paths": ["/assets/*"],
+      "environment_short": "pd",
+      "origin_hostname": "teach-production.teacherservices.cloud"
+    }
+  },
+  "rate_limit": [
+    {
+      "agent": "all",
+      "priority": 100,
+      "duration": 5,
+      "limit": 1000,
+      "selector": "Host",
+      "operator": "GreaterThanOrEqual",
+      "match_values": "0"
+    }
+  ]
+}

--- a/terraform/domains/environment_domains/config/staging.tfvars.json
+++ b/terraform/domains/environment_domains/config/staging.tfvars.json
@@ -1,0 +1,23 @@
+{
+  "hosted_zone": {
+    "teach.education.gov.uk": {
+      "front_door_name": "s189p01-teach-dom-fd",
+      "resource_group_name": "s189p01-teach-dom-rg",
+      "domains": ["staging"],
+      "cached_paths": ["/assets/*"],
+      "environment_short": "st",
+      "origin_hostname": "teach-staging.test.teacherservices.cloud"
+    }
+  },
+  "rate_limit": [
+    {
+      "agent": "all",
+      "priority": 100,
+      "duration": 5,
+      "limit": 300,
+      "selector": "Host",
+      "operator": "GreaterThanOrEqual",
+      "match_values": "0"
+    }
+  ]
+}

--- a/terraform/domains/environment_domains/main.tf
+++ b/terraform/domains/environment_domains/main.tf
@@ -1,0 +1,13 @@
+# Used to create domains to be managed by front door.
+module "domains" {
+  for_each            = var.hosted_zone
+  source              = "./vendor/modules/domains//domains/environment_domains"
+  zone                = each.key
+  front_door_name     = each.value.front_door_name
+  resource_group_name = each.value.resource_group_name
+  domains             = each.value.domains
+  environment         = each.value.environment_short
+  host_name           = each.value.origin_hostname
+  cached_paths        = try(each.value.cached_paths, [])
+  rate_limit          = try(var.rate_limit, null)
+}

--- a/terraform/domains/environment_domains/output.tf
+++ b/terraform/domains/environment_domains/output.tf
@@ -1,0 +1,14 @@
+output "hosted_zones" {
+  value = keys(var.hosted_zone)
+}
+
+output "external_urls" {
+  value = flatten([
+    for zone_name, zone_values in var.hosted_zone : [
+      for domain in zone_values["domains"] : (domain == "apex" ?
+        "https://${zone_name}" :
+        "https://${domain}.${zone_name}"
+      )
+    ]
+  ])
+}

--- a/terraform/domains/environment_domains/terraform.tf
+++ b/terraform/domains/environment_domains/terraform.tf
@@ -1,0 +1,19 @@
+terraform {
+
+  required_version = "= 1.9.8"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "3.116.0"
+    }
+  }
+  backend "azurerm" {
+    container_name = "terraform-state"
+  }
+}
+
+provider "azurerm" {
+  features {}
+
+  skip_provider_registration = true
+}

--- a/terraform/domains/environment_domains/variables.tf
+++ b/terraform/domains/environment_domains/variables.tf
@@ -1,0 +1,17 @@
+variable "hosted_zone" {
+  type    = map(any)
+  default = {}
+}
+
+variable "rate_limit" {
+  type = list(object({
+    agent        = optional(string)
+    priority     = optional(number)
+    duration     = optional(number)
+    limit        = optional(number)
+    selector     = optional(string)
+    operator     = optional(string)
+    match_values = optional(string)
+  }))
+  default = null
+}


### PR DESCRIPTION
  - Add Terraform modules for domain management via Front Door
  - Configure staging environment with rate limit of 300 requests per 5 minutes
  - Configure production environment with rate limit of 1000 requests per 5 minutes
  - Use teach.education.gov.uk domain with appropriate subdomains