### PR TITLE
Add labeller workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,25 @@
+documentation:
+- changed-files:
+  - any-glob-to-any-file: 
+      - docs/**
+
+dependencies:
+- changed-files:
+  - any-glob-to-any-file: 
+    - Gemfile.lock
+    - yarn.lock
+
+javascript:
+- changed-files:
+  - any-glob-to-any-file: 
+    - app/javascript/**
+
+github_actions:
+- changed-files:
+  - any-glob-to-any-file: 
+    - .github/**
+
+ruby:
+- changed-files:
+  - any-glob-to-any-file: 
+    - '**/*.rb'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,26 @@
+name: Label PRs
+
+on:
+  pull_request:
+    types: 
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy-label:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          labels: deploy


### PR DESCRIPTION
Adds github workflow to auto-label PRs
Will add the `deploy` label (necessary for triggering review apps) only when a PR is not in draft