### PR TITLE
Fix labeler for dependabot prs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,12 +1,16 @@
 name: Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: 
       - opened
       - reopened
       - synchronize
       - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   label:


### PR DESCRIPTION
Uses `pull_request_target` instead of `pull_request` to allow dependabot to label PRs