### PR TITLE
Fix solid queue startup

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
 web: env RUBY_DEBUG_OPEN=true bin/rails server
 css: yarn build:css --watch
 js: yarn build --watch
-jobs: bundle exec rake solid_queue:start
+jobs: bin/jobs 

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -57,7 +57,7 @@ module "worker_application" {
 
   docker_image = var.docker_image
 
-  command       = ["bundle", "exec", "rake", "solid_queue:start"]
+  command       = ["bundle", "exec", "bin/jobs"]
   probe_command = ["pgrep", "-f", "solid-queue-worker"]
 
   replicas   = var.worker_replicas


### PR DESCRIPTION
Start solid queue with `bin/jobs` instead of older `solid_queue:start` command