### PR TITLE
Remove http basic auth

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,11 +3,6 @@ class ApplicationController < ActionController::Base
 
   include Pagy::Backend
 
-  http_basic_authenticate_with(
-    name: ENV["BASIC_AUTH_USERNAME"],
-    password: ENV["BASIC_AUTH_PASSWORD"],
-  ) unless Rails.env.development? || Rails.env.test?
-
   before_action :add_home_breadcrumb
 
   def add_home_breadcrumb


### PR DESCRIPTION
### Trello card

### Context

This removes the password protection from the site ready for go live

### Changes proposed in this pull request

- Remove basic auth from `ApplicationController`

### Guidance to review

