### PR TITLE
Enable overnight db backup

### DIFF
--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -21,8 +21,8 @@ on:
         description: |
           Name of the database server. Default is the live server. When backing up a point-in-time (PTR) server, use the full name of the PTR server. (Optional)
 
-  # schedule:
-  #   - cron: "0 4 * * *" # 04:00 UTC
+  schedule:
+    - cron: "0 4 * * *" # 04:00 UTC
 
 permissions:
   id-token: write


### PR DESCRIPTION
### Trello card

https://trello.com/c/mFxbLkIX/2353-new-service-teach

### Context

Not that production environment has been deployed and running without issues we should have the backup db workflow automatically trigger overnight to take a backup of production.

### Changes proposed in this pull request

Uncomment backup DB schedule