### PR TITLE
Bump brakeman

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.0.2)
+    brakeman (7.1.0)
       racc
     builder (3.3.0)
     bundler-audit (0.9.2)


### PR DESCRIPTION
### Trello card

### Context

Dependabot is failing on `scan_ruby` because brakeman is not the latest version.

### Changes proposed in this pull request

- Bump dependabot to fix CI

### Guidance to review

