### PR TITLE
banner margin and secondary header/span tweak to make it darker

### DIFF
--- a/app/views/shared/page_headers/_default.html.erb
+++ b/app/views/shared/page_headers/_default.html.erb
@@ -9,8 +9,8 @@
 
     <div class="content-container">
       <div class="content">
-        <h1 class="govuk-heading-xl"><%= @front_matter.dig(:page_header, :title) %></h1>
-        <span class="govuk-caption-xl"><%= @front_matter.dig(:page_header, :description) %></span>
+        <h1 class="govuk-heading-xl govuk-!-margin-bottom-4"><%= @front_matter.dig(:page_header, :title) %></h1>
+        <p class="govuk-body-l govuk-!-margin-bottom-2"><%= @front_matter.dig(:page_header, :description) %></p>
       </div>
 
       <% if @front_matter.dig(:page_header, :logo) %>


### PR DESCRIPTION
### Trello card
https://trello.com/c/YgZWqLkL/431-homepage-banners-change-secondary-texts-under-h1

### Context
I have reduced the margin on the h1, and p tag below. I also changed the span to the p tag to make the text darker

### Changes proposed in this pull request
banner h1/p margins

### Guidance to review
Check h1/p tags on all banners
