### PR TITLE
adding some responsive code for cookie buttons to be full width on mobile only

### DIFF
--- a/app/assets/stylesheets/cookies.scss
+++ b/app/assets/stylesheets/cookies.scss
@@ -1,7 +1,17 @@
 // Fixes misalignment when using buttons and links in the govuk-cookies-banner
+@use "govuk-frontend/dist/govuk" as govuk;
 
 .govuk-cookie-banner {
   .govuk-button-group {
     align-items: center;
   }
+  
+  form.button_to{
+    width:100%;
+
+    @include govuk.govuk-media-query($from: tablet) {
+      width:auto;
+    }
+  }
+  
 }


### PR DESCRIPTION
### Trello card

https://trello.com/b/e2HYDCpH/get-ready-to-teach-sprint-board

### Context

cookie banner buttons full width on mobile

### Changes proposed in this pull request

adding some responsive code for cookie buttons to be full width on mobile only

### Guidance to review

check cookie banner buttons are full width on mobile