### PR TITLE
Add ability to disable pages for rendering with draft tag in frontmatter

### DIFF
--- a/app/services/content_loader.rb
+++ b/app/services/content_loader.rb
@@ -35,6 +35,8 @@ class ContentLoader
     Dir.glob("#{CONTENT_DIR}/**/*.md").each do |file_path|
       front_matter, content = parse_markdown_file(file_path)
 
+      next if front_matter.dig(:draft) == true
+
       slug = Pathname.new(file_path)
         .relative_path_from(CONTENT_DIR) # Ensure slugs reflect any nested file paths
         .to_s

--- a/app/views/content/prepare-for-training.md
+++ b/app/views/content/prepare-for-training.md
@@ -35,11 +35,6 @@ page_header:
         path: "/prepare-for-training/what-to-expect-from-your-school-based-mentor"
     ) %>
     <%= render Cards::SimpleCardComponent.new(
-        title: "Timeline of your training", 
-        description: "Find out what happens and when on initial teacher training (ITT), whether you’re training with a university or doing school centred initial teacher training (SCITT).",
-        path: "/prepare-for-training/timeline-of-your-training"
-    ) %>
-    <%= render Cards::SimpleCardComponent.new(
         title: "Advice from former trainees", 
         description: "Hear from former trainees and their advice for teacher training.",
         path: root_path

--- a/app/views/content/prepare-for-training/timeline-of-your-training.md
+++ b/app/views/content/prepare-for-training/timeline-of-your-training.md
@@ -1,6 +1,7 @@
 ---
 title: "Timeline of your training"
 layout: "article"
+draft: true
 page_header:
     title: "Timeline of your training"
     description: "Find out what happens and when on initial teacher training (ITT) whether you’re training with a university or doing school centred initial teacher training (SCITT)."

--- a/docs/content.md
+++ b/docs/content.md
@@ -12,6 +12,7 @@
     - [Variables](#variables)
     - [Side Navigation](#side-navigation)
     - [Breadcrumbs](#breadcrumbs)
+    - [Drafts](#drafts)
  3. [Creating a new page](#creating-a-new-page)
  4. [Variables](#variables)
  5. [Rails Partials](#rails-partials)
@@ -143,6 +144,9 @@ breadcrumbs:
         - path: "/"
 ```
 
+### Drafts
+
+If you want to prevent a page from being publicly accessible via its URL, you can add `draft: true` to the front matter.
 
 ## Creating a new page
 

--- a/spec/services/content_loader_spec.rb
+++ b/spec/services/content_loader_spec.rb
@@ -25,6 +25,18 @@ RSpec.describe ContentLoader do
         loader.find_by_slug("missing")
       }.to raise_error(PageNotFoundError)
     end
+
+    context "when page is draft" do
+      let(:slug) { "draft-page" }
+      let(:front_matter) { { title: "Draft Page", draft: true } }
+      let(:content) { "Content here" }
+
+      it "returns front_matter and content for a valid slug" do
+        result = loader.find_by_slug(slug)
+
+        expect(result).not_to include([ front_matter, content ])
+      end
+    end
   end
 
   describe "#navigation_items" do


### PR DESCRIPTION
### Trello card

https://trello.com/c/ab2vROd6/461-remove-timeline-page-from-prepare-for-training-this-is-not-in-mvp-launch-due-to-not-having-provider-sign-off

### Context

- We should be able to tag pages with `draft: true` to prevent them from rendering if we need to take down a page quickly without deleting it completely

### Changes proposed in this pull request

- Skip draft pages in content loader
- Add content guidance
- Add specs

### Guidance to review

