### PR TITLE
Add active state to side navigation page if on current page

### DIFF
--- a/app/assets/stylesheets/side-nav.scss
+++ b/app/assets/stylesheets/side-nav.scss
@@ -25,6 +25,12 @@
           font-weight: bold;
         }
       }
+
+      &.active{
+        font-weight: 700;
+        background: #f3f2f1;
+      }
+
     }
   }
 }

--- a/app/views/shared/_side_nav.html.erb
+++ b/app/views/shared/_side_nav.html.erb
@@ -3,7 +3,10 @@
 
   <ul>
     <% data.dig(:steps).each do |step| %>
-      <li><%= link_to step[:title], step[:href], class: "govuk-link govuk-link--no-visited-state govuk-link--no-underline" %></li>
+      <% is_active = step[:href] == "#" %>
+      <li class="<%= 'active' if is_active %>">
+        <%= link_to step[:title], step[:href], class: "govuk-link govuk-link--no-visited-state govuk-link--no-underline" %>
+      </li>
     <% end %>
   </ul>
 </aside>


### PR DESCRIPTION
### Trello card

https://trello.com/c/wWgMBm2B/469-add-active-state-to-side-navigation-page-if-on-current-page

### Context

Be nice to add an active class to the relevant li item, to make it more obvious what the current page is 

### Changes proposed in this pull request

add logic to detect which a tag has '#' to determine it is the current page, and add an active class to the relevant li item

### Guidance to review

check if the current page changes visually with bold text and a background, can also inspect page to see 'active' class applied