### PR TITLE
Accessibility add alt text to logo

### DIFF
--- a/app/views/content/home.md
+++ b/app/views/content/home.md
@@ -14,8 +14,7 @@ breadcrumbs:
     description: "Find out how you can prepare for your teacher training, from what to expect from your training provider to preparing for your first placement.",
     button_text: "Prepare for your training",
     button_href: "/prepare-for-training/how-to-prepare-for-teacher-training",
-    image: "content/teacher2.png",
-    image_alt: "A teacher smiling with a group of students"
+    image: "content/teacher2.png"
 ) %>
 
 <%= render "content/home/next_steps" %>


### PR DESCRIPTION
### Trello card
https://trello.com/c/PJmdfclN/479-accessibility-teacher-logo-on-homepage-doesnt-have-alt-text

### Context
logo on home page is missing alt text, so added some in for screen readers

### Changes proposed in this pull request
state the image is a logo 

### Guidance to review
Test using a screen reader that the image has some alt, or inspect the image in the browser to see alt text
