### PR TITLE
Side navigation accessibility improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "mission_control-jobs"
 gem "validate_url"
 gem "sentry-ruby"
 gem "sentry-rails"
+gem "active_link_to"
 
 group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,9 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_link_to (1.0.5)
+      actionpack
+      addressable
     activejob (8.0.2)
       activesupport (= 8.0.2)
       globalid (>= 0.3.6)
@@ -418,6 +421,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  active_link_to
   bootsnap
   brakeman
   bundler-audit

--- a/app/views/content/get-support/get-support-outside-your-training.md
+++ b/app/views/content/get-support/get-support-outside-your-training.md
@@ -7,10 +7,10 @@ page_header:
 side_navigation:
     title: Get support
     steps:
-        - title: Get support outside your training
-          href: "#"
         - title: Get support through your training course 
           href: "/get-support/get-support-through-your-training-course"
+        - title: Get support outside your training
+          href: "/get-support/get-support-outside-your-training"
 breadcrumbs: 
     enable: true
     crumbs: 

--- a/app/views/content/get-support/get-support-through-your-training-course.md
+++ b/app/views/content/get-support/get-support-through-your-training-course.md
@@ -8,7 +8,7 @@ side_navigation:
     title: Get support
     steps:
         - title: Get support through your training course 
-          href: "#"
+          href: "/get-support/get-support-through-your-training-course"
         - title: Get support outside your training
           href: "/get-support/get-support-outside-your-training"
 breadcrumbs: 

--- a/app/views/content/prepare-for-training/advice-from-former-trainees.md
+++ b/app/views/content/prepare-for-training/advice-from-former-trainees.md
@@ -7,10 +7,10 @@ page_header:
 side_navigation:
     title: Prepare for training
     steps:
-        - title: Prepare for your first school placement
-          href: "#"
         - title: How to prepare for teacher training
           href: "/prepare-for-training/how-to-prepare-for-teacher-training"
+        - title: Prepare for your first school placement
+          href: "/prepare-for-training/prepare-for-your-first-school-placement"
         - title: What to expect from your teacher training provider
           href: "/prepare-for-training/what-to-expect-from-your-teacher-training-provider"
         - title: What to expect from your school-based mentor

--- a/app/views/content/prepare-for-training/how-to-prepare-for-teacher-training.md
+++ b/app/views/content/prepare-for-training/how-to-prepare-for-teacher-training.md
@@ -8,7 +8,7 @@ side_navigation:
     title: Prepare for training
     steps:
         - title: How to prepare for teacher training
-          href: "#"
+          href: "/prepare-for-training/how-to-prepare-for-teacher-training"
         - title: Prepare for your first school placement
           href: "/prepare-for-training/prepare-for-your-first-school-placement"
         - title: What to expect from your teacher training provider
@@ -16,7 +16,7 @@ side_navigation:
         - title: What to expect from your school-based mentor
           href: "/prepare-for-training/what-to-expect-from-your-school-based-mentor"
         - title: Advice from former trainees
-          href: "#"
+          href: "/prepare-for-training/advice-from-former-trainees"
 breadcrumbs: 
     enable: true
     crumbs: 

--- a/app/views/content/prepare-for-training/prepare-for-your-first-school-placement.md
+++ b/app/views/content/prepare-for-training/prepare-for-your-first-school-placement.md
@@ -7,16 +7,16 @@ page_header:
 side_navigation:
     title: Prepare for training
     steps:
-        - title: Prepare for your first school placement
-          href: "#"
         - title: How to prepare for teacher training
           href: "/prepare-for-training/how-to-prepare-for-teacher-training"
+        - title: Prepare for your first school placement
+          href: "/prepare-for-training/prepare-for-your-first-school-placement"
         - title: What to expect from your teacher training provider
           href: "/prepare-for-training/what-to-expect-from-your-teacher-training-provider"
         - title: What to expect from your school-based mentor
           href: "/prepare-for-training/what-to-expect-from-your-school-based-mentor"
         - title: Advice from former trainees
-          href: "#"
+          href: "/prepare-for-training/advice-from-former-trainees"
 breadcrumbs: 
     enable: true
     crumbs: 

--- a/app/views/content/prepare-for-training/timeline-of-your-training.md
+++ b/app/views/content/prepare-for-training/timeline-of-your-training.md
@@ -7,16 +7,16 @@ page_header:
 side_navigation:
     title: Prepare for training
     steps:
-        - title: Prepare for your first school placement
-          href: "#"
         - title: How to prepare for teacher training
-          href: "#"
+          href: "/prepare-for-training/how-to-prepare-for-teacher-training"
+        - title: Prepare for your first school placement
+          href: "/prepare-for-training/prepare-for-your-first-school-placement"
         - title: What to expect from your teacher training provider
-          href: "#"
+          href: "/prepare-for-training/what-to-expect-from-your-teacher-training-provider"
         - title: What to expect from your school-based mentor
-          href: "#"
-        - title: Timeline of your training
-          href: "#"
+          href: "/prepare-for-training/what-to-expect-from-your-school-based-mentor"
+        - title: Advice from former trainees
+          href: "/prepare-for-training/advice-from-former-trainees"
 breadcrumbs: 
     enable: true
     crumbs: 

--- a/app/views/content/prepare-for-training/what-to-expect-from-your-school-based-mentor.md
+++ b/app/views/content/prepare-for-training/what-to-expect-from-your-school-based-mentor.md
@@ -7,16 +7,16 @@ page_header:
 side_navigation:
     title: Prepare for training
     steps:
-        - title: What to expect from your school-based mentor
-          href: "#"
-        - title: Prepare for your first school placement
-          href: "/prepare-for-training/prepare-for-your-first-school-placement"
         - title: How to prepare for teacher training
           href: "/prepare-for-training/how-to-prepare-for-teacher-training"
+        - title: Prepare for your first school placement
+          href: "/prepare-for-training/prepare-for-your-first-school-placement"
         - title: What to expect from your teacher training provider
           href: "/prepare-for-training/what-to-expect-from-your-teacher-training-provider"
+        - title: What to expect from your school-based mentor
+          href: "/prepare-for-training/what-to-expect-from-your-school-based-mentor"
         - title: Advice from former trainees
-          href: "#"
+          href: "/prepare-for-training/advice-from-former-trainees"
 breadcrumbs: 
     enable: true
     crumbs: 

--- a/app/views/content/prepare-for-training/what-to-expect-from-your-teacher-training-provider.md
+++ b/app/views/content/prepare-for-training/what-to-expect-from-your-teacher-training-provider.md
@@ -7,16 +7,16 @@ page_header:
 side_navigation:
     title: Prepare for training
     steps:
-        - title: What to expect from your teacher training provider
-          href: "#"
-        - title: Prepare for your first school placement
-          href: "/prepare-for-training/prepare-for-your-first-school-placement"
         - title: How to prepare for teacher training
           href: "/prepare-for-training/how-to-prepare-for-teacher-training"
+        - title: Prepare for your first school placement
+          href: "/prepare-for-training/prepare-for-your-first-school-placement"
+        - title: What to expect from your teacher training provider
+          href: "/prepare-for-training/what-to-expect-from-your-teacher-training-provider"
         - title: What to expect from your school-based mentor
           href: "/prepare-for-training/what-to-expect-from-your-school-based-mentor"
         - title: Advice from former trainees
-          href: "#"
+          href: "/prepare-for-training/advice-from-former-trainees"
 breadcrumbs: 
     enable: true
     crumbs: 

--- a/app/views/content/resources-while-training/behaviour-management.md
+++ b/app/views/content/resources-while-training/behaviour-management.md
@@ -7,10 +7,10 @@ page_header:
 side_navigation:
     title: Resources while training
     steps:
-        - title: Behaviour management 
-          href: "#"
         - title: Lesson planning as a trainee teacher 
           href: "/resources-while-training/lesson-planning-as-a-trainee-teacher"
+        - title: Behaviour management 
+          href: "/resources-while-training/behaviour-management"
         - title: Meeting the teachers' standards 
           href: "/resources-while-training/meeting-the-teachers-standards"
 breadcrumbs: 

--- a/app/views/content/resources-while-training/lesson-planning-as-a-trainee-teacher.md
+++ b/app/views/content/resources-while-training/lesson-planning-as-a-trainee-teacher.md
@@ -8,7 +8,7 @@ side_navigation:
     title: Resources while training
     steps:
         - title: Lesson planning as a trainee teacher 
-          href: "#"
+          href: "/resources-while-training/lesson-planning-as-a-trainee-teacher"
         - title: Behaviour management 
           href: "/resources-while-training/behaviour-management"
         - title: Meeting the teachers' standards 

--- a/app/views/content/resources-while-training/meeting-the-teachers-standards.md
+++ b/app/views/content/resources-while-training/meeting-the-teachers-standards.md
@@ -7,12 +7,12 @@ page_header:
 side_navigation:
     title: Resources while training
     steps:
-        - title: Meeting the teachers' standards 
-          href: "#"
         - title: Lesson planning as a trainee teacher 
           href: "/resources-while-training/lesson-planning-as-a-trainee-teacher"
         - title: Behaviour management 
           href: "/resources-while-training/behaviour-management"
+        - title: Meeting the teachers' standards 
+          href: "/resources-while-training/meeting-the-teachers-standards"
 breadcrumbs: 
     enable: true
     crumbs: 

--- a/app/views/shared/_side_nav.html.erb
+++ b/app/views/shared/_side_nav.html.erb
@@ -1,9 +1,11 @@
 <aside class="side-navigation">
-  <h2 class="govuk-heading-m"><%= data[:title] %></h2>
+  <nav aria-labelledby="side-navigation-label">
+    <h2 id="side-navigation-label" class="govuk-heading-m"><%= data[:title] %></h2>
 
-  <ul>
-    <% data.dig(:steps).each do |step| %>
-      <li><%= link_to step[:title], step[:href], class: "govuk-link govuk-link--no-visited-state govuk-link--no-underline" %></li>
-    <% end %>
-  </ul>
+    <ul>
+      <% data.dig(:steps).each do |step| %>
+        <li><%= active_link_to step[:title], step[:href], class: "govuk-link govuk-link--no-visited-state", class_active: "active" %></li>
+      <% end %>
+    </ul>
+  </nav>
 </aside>


### PR DESCRIPTION
### Trello card

https://trello.com/c/wWgMBm2B/469-add-active-state-to-side-navigation-page-if-on-current-page
https://trello.com/c/PBFRyZ3a/480-accessibility-heading-level-2-on-side-navigation-content-pages-should-actually-make-it-clear-to-people-that-the-navigation-below

### Context

The side navigation was flagged in accessibility testing. We need to fix this to be more accessible. Additionally, we need to add an active state to the current page in the side nav.

### Changes proposed in this pull request

- Make side nav a `nav` element
- Add aria tag to associate the h2 with the nav as a label
- Add `active_link_to` to render an active state for the current page
- Fixes consistency issues with the side navigation so it is the same ordering across all pages
- Add missing links

### Guidance to review

- Side nav should have consistent ordering across all pages
- Side nav should be accessible for screen readers
- h2 for side nav should now be associated with the nav for accessibility
- Side nav should bold the current page

