### PR TITLE
adding gov.uk link to DFE logo but wondering if we should also add aria-label="DfE homepage" like DFE design example

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,7 @@
 <header class="govuk-header" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo">
-      <%= link_to root_path, class: "govuk-header__link govuk-header__link--homepage" do %>
+      <%= link_to "https://gov.uk", class: "govuk-header__link govuk-header__link--homepage" do %>
         <%= image_tag "department-for-education_white.png", alt: "Department for Education", class: "govuk-header__logotype govuk-header__logotype--default" %>
         <%= image_tag "department-for-education_black.png", alt: "Department for Education", class: "govuk-header__logotype govuk-header__logotype--focus" %>
       <% end %>


### PR DESCRIPTION
### Trello card
https://trello.com/c/cCZ9CQyn/481-accessibility-header-logo-dfe-logo-or-gov-uk-logo-should-this-go-to-the-dfe-home-page-or-our-service-home-page

### Context
adding gov.uk link to DFE logo but wondering if we should also add aria-label="DfE homepage" like DFE design example

### Changes proposed in this pull request
adding gov.uk link to DFE logo but wondering if we should also add aria-label="DfE homepage" like DFE design example

### Guidance to review
Check dfe logo goes to gov.uk
