### PR TITLE
adding visually hidden text to state it is an external link for screen readers

### DIFF
--- a/app/views/content/get-support/get-support-outside-your-training.md
+++ b/app/views/content/get-support/get-support-outside-your-training.md
@@ -29,7 +29,7 @@ The Education Support charity provides a helpline for teacher trainees, offering
 ### Need to talk?
 Call <%= govuk_link_to "08000 562 561", "tel:08000562561" %>
 
-You can also use <%= govuk_link_to "Education Support's wellbeing resources", "https://www.educationsupport.org.uk/resources/for-individuals/" %>.
+You can also use <a class="govuk-link" href="https://www.educationsupport.org.uk/resources/for-individuals/">Education Support’s wellbeing resources<span class="govuk-visually-hidden">. This is an external link.</span></a>.
 
 ## Paid for support services
 ### Edapt
@@ -41,7 +41,7 @@ They offer an alternative to trade unions and can provide:
 - professional support from experts in education
 - support through disciplinary, grievance or allegations made against you
 
-<%= govuk_link_to "Explore Edapt", "https://www.edapt.org.uk/" %>.
+<a class="govuk-link" href="https://www.edapt.org.uk/">Explore Edapt<span class="govuk-visually-hidden">. This is an external link.</span></a>
 
 ### Unions
 You are eligible as a trainee teacher to join a teaching union.
@@ -56,6 +56,6 @@ A union can offer:
 
 Some examples include the following:
 
-- <%= govuk_link_to "National Education Union", "https://neu.org.uk/advice/member-groups/new-teachers" %>
-- <%= govuk_link_to "National Association of Schoolmasters Union of Women Teachers (NASUWT)", "https://www.nasuwt.org.uk/advice/student-hub.html" %>
-- <%= govuk_link_to "Community Trade Union", "https://community-tu.org/who-we-are/our-sectors/education-and-early-years/teachers-tutors-and-lecturers/" %>
+- <a class="govuk-link" href="https://neu.org.uk/advice/member-groups/new-teachers">National Education Union<span class="govuk-visually-hidden">. This is an external link.</span></a>
+- <a class="govuk-link" href="https://www.nasuwt.org.uk/advice/student-hub.html">National Association of Schoolmasters Union of Women Teachers (NASUWT)<span class="govuk-visually-hidden">. This is an external link.</span></a>
+- <a class="govuk-link" href="https://community-tu.org/who-we-are/our-sectors/education-and-early-years/teachers-tutors-and-lecturers/">Community Trade Union<span class="govuk-visually-hidden">. This is an external link.</span></a>

--- a/app/views/content/resources-while-training/behaviour-management.md
+++ b/app/views/content/resources-while-training/behaviour-management.md
@@ -47,6 +47,8 @@ If you find that what you’re implementing is not effective, talk to your mento
 
 You could also:
 
-- read <%= govuk_link_to "behaviour tips for teacher trainees from the National Education Union", "https://neu.org.uk/advice/member-groups/new-teachers/behaviour-tips-trainee-teachers" %>
-- watch <%= govuk_link_to "top behaviour management tips for new teachers from NASUWT", "https://www.nasuwt.org.uk/advice/student-hub/top-behaviour-management-tips-from-nqts.html" %>
-- explore <%= govuk_link_to "The Chartered College of Teaching’s managing behaviour resources", "https://my.chartered.college/ecf_framework/ecf-standard-7-managing-behaviour/" %>
+- read <a class="govuk-link" href="https://neu.org.uk/advice/member-groups/new-teachers/behaviour-tips-trainee-teachers">behaviour tips for teacher trainees from the National Education Union<span class="govuk-visually-hidden">. This is an external link.</span></a>
+- watch <a class="govuk-link" href="https://www.nasuwt.org.uk/advice/student-hub/top-behaviour-management-tips-from-nqts.html">top behaviour management tips for new teachers from NASUWT<span class="govuk-visually-hidden">. This is an external link.</span></a>
+- explore <a class="govuk-link" href="https://my.chartered.college/ecf_framework/ecf-standard-7-managing-behaviour/">The Chartered College of Teaching’s managing behaviour resources<span class="govuk-visually-hidden">. This is an external link.</span></a>
+
+

--- a/app/views/content/resources-while-training/lesson-planning-as-a-trainee-teacher.md
+++ b/app/views/content/resources-while-training/lesson-planning-as-a-trainee-teacher.md
@@ -76,10 +76,10 @@ Some will provide access to free resources whereas some will require a membershi
 
 ## Lesson planning resources
 ### The Chartered College of Teaching tips
-Before you start your training, you could <%= govuk_link_to "read some lesson planning tips for trainees from the Chartered College of Teaching", "https://my.chartered.college/early-career-hub/lesson-planning/" %>.
+Before you start your training, you could <a class="govuk-link" href="https://my.chartered.college/early-career-hub/lesson-planning/">read some lesson planning tips for trainees from the Chartered College of Teaching<span class="govuk-visually-hidden">. This is an external link.</span></a>.
 
 ### Oak National Academy
 If you’re looking for more inspiration for your lesson planning, you could consider resources from Oak National Academy for:
 
-- <%= govuk_link_to "key stage 3 (KS3)", "https://www.thenational.academy/teachers/key-stages/ks3/subjects" %>
-- <%= govuk_link_to "key stage 4 (KS4)", "https://www.thenational.academy/teachers/key-stages/ks4/subjects" %>
+- <a class="govuk-link" href="https://www.thenational.academy/teachers/key-stages/ks3/subjects">key stage 3 (KS3)<span class="govuk-visually-hidden">. This is an external link.</span></a>
+- <a class="govuk-link" href="https://www.thenational.academy/teachers/key-stages/ks4/subjects">key stage 4 (KS4)<span class="govuk-visually-hidden">. This is an external link.</span></a>


### PR DESCRIPTION
### Trello card
https://trello.com/c/s2XVMFtR/482-accessibility-check-all-links-across-service-to-make-it-clear-to-people-that-they-are-going-to-an-external-site

### Context
adding visually hidden text to state it is an external link for screen readers


### Changes proposed in this pull request
adding in html for links so I can add in visually hidden text using govuk-visually-hidden spans 

### Guidance to review
use a screen reader across the three pages to check if 'this is an external link' is read out at the end of links
