### PR TITLE
Add alt text option to card with image component

### DIFF
--- a/app/components/cards/card_with_image_component.html.erb
+++ b/app/components/cards/card_with_image_component.html.erb
@@ -8,6 +8,6 @@
   </div>
 
   <% if @image %>
-    <%= image_tag @image %>
+    <%= image_tag @image, alt: @image_alt %>
   <% end %>
 </div>

--- a/app/components/cards/card_with_image_component.rb
+++ b/app/components/cards/card_with_image_component.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 class Cards::CardWithImageComponent < ViewComponent::Base
-  def initialize(title:, description:, image: nil, button_text:, button_href:, heading_tag: "h2", background_color: "light-blue")
+  def initialize(title:, description:, image: nil, image_alt: nil, button_text:, button_href:, heading_tag: "h2", background_color: "light-blue")
     @title = title
     @description = description
     @button_text = button_text
     @button_href = button_href
     @heading_tag = heading_tag
     @image = image
+    @image_alt = image_alt
     @background_color = background_color
   end
 end

--- a/app/views/content/home.md
+++ b/app/views/content/home.md
@@ -14,7 +14,8 @@ breadcrumbs:
     description: "Find out how you can prepare for your teacher training, from what to expect from your training provider to preparing for your first placement.",
     button_text: "Prepare for your training",
     button_href: "/prepare-for-training/how-to-prepare-for-teacher-training",
-    image: "content/teacher2.png"
+    image: "content/teacher2.png",
+    image_alt: "Image of a teacher in a classroom"
 ) %>
 
 <%= render "content/home/next_steps" %>

--- a/spec/components/cards/card_with_image_component_spec.rb
+++ b/spec/components/cards/card_with_image_component_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Cards::CardWithImageComponent, type: :component do
   let(:title) { "Title" }
   let(:description) { "Description" }
   let(:image) { "image.png" }
+  let(:image_alt) { "image alt text" }
   let(:button_text) { "Click me" }
   let(:button_href) { "/" }
 
@@ -45,6 +46,7 @@ RSpec.describe Cards::CardWithImageComponent, type: :component do
 
   context "with an image" do
     let(:image) { "fake-image.png" }
+    let(:image_alt) { "fake image alt text" }
 
     let(:component) {
       described_class.new(
@@ -52,10 +54,12 @@ RSpec.describe Cards::CardWithImageComponent, type: :component do
         description: description,
         button_text: button_text,
         button_href: button_href,
-        image: image
+        image: image,
+        image_alt: image_alt
       )
     }
 
     it { is_expected.to have_css("img[src*='assets/fake-image']") }
+    it { is_expected.to have_css("img[alt*='#{image_alt}']") }
   end
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/R30hnTti/487-accessibility-how-to-prepare-for-teacher-training-homepage-banner-image-doesnt-have-alt-text?filter=member:spencerldixon

### Context

We need to add alt text to the images in the `CardWithImageComponent`

### Changes proposed in this pull request

- Adds `image_alt` option
- Sets alt text for image on home page

### Guidance to review

