### PR TITLE
Conditional to enable clarity only in production environment

### DIFF
--- a/app/views/shared/analytics/_clarity.html.erb
+++ b/app/views/shared/analytics/_clarity.html.erb
@@ -1,4 +1,4 @@
-<% if non_essential_cookies_accepted? %>
+<% if non_essential_cookies_accepted? && Rails.env.production? %>
   <script type="text/javascript">
     (function(c,l,a,r,i,t,y){
         c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};


### PR DESCRIPTION
### Trello card

https://trello.com/c/Cy7W9z8l/459-separation-of-environment-data-in-ms-clarity

### Context

We only want production data in clarity, so we need to make sure it only shows in the production environment.

### Changes proposed in this pull request

- Add conditional to only show clarity in production

### Guidance to review

