### PR TITLE
Adding quotes throughout service with blue quote block, also fixes the spacing issue on the 'advice from trainees' page in the backlog

### DIFF
--- a/app/components/cards/quote_component.html.erb
+++ b/app/components/cards/quote_component.html.erb
@@ -1,4 +1,4 @@
-<div class="quote <%= @classes %>"">
+<div class="quote <%= @classes %>">
   <blockquote>
     <%= @text %>
   </blockquote>

--- a/app/components/cards/quote_component.html.erb
+++ b/app/components/cards/quote_component.html.erb
@@ -1,6 +1,8 @@
-<div class="quote">
+<div class="quote <%= @classes %>"">
   <blockquote>
     <%= @text %>
   </blockquote>
   <p class="quote__attribution"><%= @attribution %></p>
 </div>
+
+

--- a/app/components/cards/quote_component.rb
+++ b/app/components/cards/quote_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Cards::QuoteComponent < ViewComponent::Base
-  def initialize(text:, attribution:, classes: "")
+  def initialize(text:, attribution:, classes: "nil")
     @text = text
     @attribution = attribution
     @classes = classes

--- a/app/components/cards/quote_component.rb
+++ b/app/components/cards/quote_component.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class Cards::QuoteComponent < ViewComponent::Base
-  def initialize(text:, attribution:)
+  def initialize(text:, attribution:, classes: "")
     @text = text
     @attribution = attribution
+    @classes = classes
   end
 end

--- a/app/components/cards/quote_component.rb
+++ b/app/components/cards/quote_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Cards::QuoteComponent < ViewComponent::Base
-  def initialize(text:, attribution:, classes: "nil")
+  def initialize(text:, attribution:, classes: nil)
     @text = text
     @attribution = attribution
     @classes = classes

--- a/app/views/content/get-support/get-support-outside-your-training.md
+++ b/app/views/content/get-support/get-support-outside-your-training.md
@@ -21,6 +21,12 @@ breadcrumbs:
 ---
 If you need to talk to someone outside of your training provider or placement schools, there are places you can reach out to.
 
+<%= render Cards::QuoteComponent.new(
+    text: "I utilised support from as many avenues as possible. Having anxiety can make things super challenging sometimes, and having support isn’t a bad thing.",
+    attribution: "English trainee from 2024/25",
+    classes: "govuk-!-margin-bottom-5"
+) %>
+
 Department for Education is not responsible for the content of resources outside of GOV.UK. These links are an example of external resources trainees may want to use and may include paid for services.
 
 ## Education Support charity

--- a/app/views/content/get-support/get-support-through-your-training-course.md
+++ b/app/views/content/get-support/get-support-through-your-training-course.md
@@ -26,6 +26,12 @@ There are lots of people on hand to support you during your training. These migh
 - provider-based mentor or tutor
 - training provider
 
+<%= render Cards::QuoteComponent.new(
+    text: "Support is always available – university tutors, school mentors, and the SLT are there to help. It is important to speak up and not suffer in silence.",
+    attribution: "Religious education (RE) trainee from 2024/25",
+    classes: "govuk-!-margin-bottom-5"
+) %>
+
 ## Your school-based mentor
 Your school-based mentor is there to support you with your day-to-day learning and development in your placement school. They can help you:
 

--- a/app/views/content/prepare-for-training/advice-from-former-trainees.md
+++ b/app/views/content/prepare-for-training/advice-from-former-trainees.md
@@ -28,96 +28,108 @@ breadcrumbs:
 
 ## What advice would you give to those about to start teacher training?
 
-<div class="govuk-grid-row govuk-!-margin-bottom-6">
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
     <%= render Cards::QuoteComponent.new(
         text: "You won’t be perfect on day one and that’s okay. Teacher training is about growth, not perfection.",
-        attribution: "Maths trainee"
+        attribution: "Maths trainee",
+        classes: "govuk-!-margin-bottom-5"
     ) %>
   </div>
   <div class="govuk-grid-column-one-half">
     <%= render Cards::QuoteComponent.new(
         text: "Don’t struggle alone – everyone feels overwhelmed at times and like it’s impossible. Share your worries with those around you because others will be feeling the same!",
-        attribution: "Religious education (RE) trainee"
+        attribution: "Religious education (RE) trainee",
+        classes: "govuk-!-margin-bottom-5"
     ) %>
   </div>
 </div>
 
-<div class="govuk-grid-row govuk-!-margin-bottom-6">
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
     <%= render Cards::QuoteComponent.new(
         text: "Remember that you are in the process of learning; there will be lessons which don't go to plan and that's absolutely okay. You aren't expected to be a perfect teacher – all that matters is that you learn from the experience.",
-        attribution: "History trainee"
+        attribution: "History trainee",
+        classes: "govuk-!-margin-bottom-5"
     ) %>
   </div>
   <div class="govuk-grid-column-one-half">
     <%= render Cards::QuoteComponent.new(
         text: "Stay ahead – you have 3 babies that you’ll need to constantly take care of: your teaching, your assignments and your portfolio. Pay each an appropriate amount of attention and they will never need to cry.",
-        attribution: "Maths trainee"
+        attribution: "Maths trainee",
+        classes: "govuk-!-margin-bottom-5"
     ) %>
   </div>
 </div>
 
 ## What was the most challenging part of teacher training and how did you deal with it?
 
-<div class="govuk-grid-row govuk-!-margin-bottom-6">
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
     <%= render Cards::QuoteComponent.new(
         text: "The most challenging part is the imposter syndrome. You will feel like you are not good enough and that you can’t do this. This is normal – fake it until you make it!",
-        attribution: "Science trainee"
+        attribution: "Science trainee",
+        classes: "govuk-!-margin-bottom-5"
     ) %>
   </div>
   <div class="govuk-grid-column-one-half">
     <%= render Cards::QuoteComponent.new(
         text: "Actually stepping in front of a class to teach them for the first time. It almost feels like you're being pushed in at the deep end but once you've taught for the first time, it's a massive weight off your shoulders and it starts to feel more natural.",
-        attribution: "Maths trainee"
+        attribution: "Maths trainee",
+        classes: "govuk-!-margin-bottom-5"
     ) %>
   </div>
 </div>
 
-<div class="govuk-grid-row govuk-!-margin-bottom-6">
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
     <%= render Cards::QuoteComponent.new(
         text: "How long it takes to plan lessons – stick with it because you'll get quicker and better every day. A quote I remember is, ‘It never gets easier, you just get better.’",
-        attribution: "Physical education (PE) trainee"
+        attribution: "Physical education (PE) trainee",
+        classes: "govuk-!-margin-bottom-5"
     ) %>
   </div>
   <div class="govuk-grid-column-one-half">
     <%= render Cards::QuoteComponent.new(
         text: "Your placement schools should be different, so prepare for your school experiences to vary. I was surprised by how much schools can differ.",
-        attribution: "English trainee"
+        attribution: "English trainee",
+        classes: "govuk-!-margin-bottom-5"
     ) %>
   </div>
 </div>
 
 ## What resources or tools did you find the most useful during your training?
 
-<div class="govuk-grid-row govuk-!-margin-bottom-6">
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
     <%= render Cards::QuoteComponent.new(
         text: "Excel spreadsheet for medium term planning – a lifesaver! A sheet for each term, scheme of work, calendar for the year and a to do list.",
-        attribution: "Science trainee"
+        attribution: "Science trainee",
+        classes: "govuk-!-margin-bottom-5"
     ) %>
   </div>
   <div class="govuk-grid-column-one-half">
     <%= render Cards::QuoteComponent.new(
         text: "Generative AI is not a bad word! It's incredibly helpful for planning activities or prompting ideas, like a super helpful assistant.",
-        attribution: "Geography trainee"
+        attribution: "Geography trainee",
+        classes: "govuk-!-margin-bottom-5"
     ) %>
   </div>
 </div>
 
-<div class="govuk-grid-row govuk-!-margin-bottom-6">
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
     <%= render Cards::QuoteComponent.new(
         text: "There are so many online resources now that you can always find slides that you can edit rather than starting from scratch. You can save yourself so much time by looking around.",
-        attribution: "Maths trainee"
+        attribution: "Maths trainee",
+        classes: "govuk-!-margin-bottom-5"
     ) %>
   </div>
   <div class="govuk-grid-column-one-half">
     <%= render Cards::QuoteComponent.new(
         text: "Other teachers! Ask them how they deal with that year group who’s driving you mad. Ask them how they usually teach this scheme of work. Ask them for advice on how to handle workload. They are there to help and usually love sharing expertise.",
-        attribution: "Drama and English trainee"
+        attribution: "Drama and English trainee",
+        classes: "govuk-!-margin-bottom-5"
     ) %>
   </div>
 </div>
@@ -125,17 +137,19 @@ breadcrumbs:
 ## Is there anything you would have done differently to prepare for training?
 
 
-<div class="govuk-grid-row govuk-!-margin-bottom-6">
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
     <%= render Cards::QuoteComponent.new(
         text: "Increased subject and curriculum knowledge, if I’d already had this, planning would have been significantly easier.",
-        attribution: "Maths trainee"
+        attribution: "Maths trainee",
+        classes: "govuk-!-margin-bottom-5"
     ) %>
   </div>
   <div class="govuk-grid-column-one-half">
     <%= render Cards::QuoteComponent.new(
         text: "Look up the national curriculum to give you an overview of what it is you’ll need to look up and teach.",
-        attribution: "History trainee"
+        attribution: "History trainee",
+        classes: "govuk-!-margin-bottom-5"
     ) %>
   </div>
 </div>
@@ -144,7 +158,8 @@ breadcrumbs:
   <div class="govuk-grid-column-one-half">
     <%= render Cards::QuoteComponent.new(
         text: "Get as much experience in school as possible, as this tells you a lot about how schools work and function.",
-        attribution: "Maths trainee"
+        attribution: "Maths trainee",
+        classes: "govuk-!-margin-bottom-5"
     ) %>
   </div>
   <div class="govuk-grid-column-one-half">

--- a/app/views/content/prepare-for-training/how-to-prepare-for-teacher-training.md
+++ b/app/views/content/prepare-for-training/how-to-prepare-for-teacher-training.md
@@ -35,6 +35,12 @@ You can also try the <%= govuk_link_to "realistic job preview tool", "https://pl
 
 You don't have to have classroom experience before you start training, but it could help you feel better prepared.
 
+<%= render Cards::QuoteComponent.new(
+    text: "Get as much experience in school as possible, as this tells you a lot about how schools work and function.",
+    attribution: "Maths trainee from 2024/25",
+    classes: "govuk-!-margin-bottom-5"
+) %>
+
 <%= govuk_button_link_to "Get school experience", "https://getintoteaching.education.gov.uk/train-to-be-a-teacher/get-school-experience" %>
 
 ## Find out about funding

--- a/app/views/content/prepare-for-training/prepare-for-your-first-school-placement.md
+++ b/app/views/content/prepare-for-training/prepare-for-your-first-school-placement.md
@@ -30,6 +30,12 @@ Your first school placement will be your chance to understand what teaching in a
 
 The school should provide you with all the information you need during your induction or onboarding, but it might be worth considering what would be useful to ask and things to be aware of.
 
+<%= render Cards::QuoteComponent.new(
+    text: "Watch how experienced teachers manage behaviour, explain concepts, and adapt their lessons. These real-life lessons are gold. Learn from feedback, even when it stings, it’s not personal, it’s professional.",
+    attribution: "Science trainee from 2024/25",
+    classes: "govuk-!-margin-bottom-5"
+) %>
+
 ## Access the school
 
 Your school should let you know:
@@ -72,6 +78,12 @@ Part of the <%= govuk_link_to "teachers’ standards", "https://www.gov.uk/gover
 
 This will be an important part of being in the classroom and joining the school environment as a member of staff. Think about the dress code and how you might conduct yourself both in the classroom and out, like in the staffroom.
 
+<%= render Cards::QuoteComponent.new(
+    text: "Remember that professionalism is the key. Ensure that you make positive relationships with all staff on your placements and turn up every day on time.",
+    attribution: "Geography trainee from 2024/25",
+    classes: "govuk-!-margin-bottom-5"
+) %>
+
 ## Reasonable adjustments
 
 If you need support during your training, you should talk to your school and provider about any reasonable adjustments you may need in place ahead of time.
@@ -105,3 +117,9 @@ You'll not have to worry about planning any lessons straight away but it's usefu
 Your placement school might use specific lesson planning resources that you’ll be able to access.
 
 You can also <%= govuk_link_to "find alternative lesson planning resources and tips", "/resources-while-training/lesson-planning-as-a-trainee-teacher" %>.
+
+<%= render Cards::QuoteComponent.new(
+    text: "Be prepared for bad days or bad lessons. The best planned lessons can go unexpectedly wrong in ways you can’t control. Get used to planning the next lesson as soon as that lesson has finished.",
+    attribution: "Physical education (PE) trainee from 2024/25",
+    classes: "govuk-!-margin-bottom-5"
+) %>

--- a/app/views/content/prepare-for-training/what-to-expect-from-your-school-based-mentor.md
+++ b/app/views/content/prepare-for-training/what-to-expect-from-your-school-based-mentor.md
@@ -43,6 +43,12 @@ Your mentor is responsible for making sure your teaching is observed and you're 
 
 They’ll help you set targets and understand how to improve, making sure you understand the curriculum and how to effectively put your teaching skills into practice.
 
+<%= render Cards::QuoteComponent.new(
+    text: "Teacher training requires openness to difficult feedback and the ability to reflect honestly. Rather than becoming defensive, I learned to embrace critique.",
+    attribution: "Religious education (RE) trainee from 2024/25",
+    classes: "govuk-!-margin-bottom-5"
+) %>
+
 ## Assess your progress
 You’ll have informal and formal assessment points throughout your training – these are called formative and summative assessments.
 
@@ -83,3 +89,9 @@ They'll work closely with your mentor to provide feedback on your progress.
 Many trainees experience support from the wider school team, not just their mentors.
 
 You’ll likely observe a few different teachers throughout the school and may have a few of them observing you.
+
+<%= render Cards::QuoteComponent.new(
+    text: "Ask for help a lot! Whether it is asking for resources, for advice on planning or behaviour management – they will understand.",
+    attribution: "Modern foreign langauges (MFL) trainee from 2024/25",
+    classes: "govuk-!-margin-bottom-5"
+) %>

--- a/app/views/content/prepare-for-training/what-to-expect-from-your-teacher-training-provider.md
+++ b/app/views/content/prepare-for-training/what-to-expect-from-your-teacher-training-provider.md
@@ -39,6 +39,12 @@ If you’re doing a postgraduate certificate in education (PGCE) alongside quali
 
 These can sometimes come at the same time so it would be useful to know when these are so that you can plan and manage your time. For example, if you need to take into account things such as childcare.
 
+<%= render Cards::QuoteComponent.new(
+    text: "I think the biggest challenge was trying to balance my university work with the increasing teaching load.",
+    attribution: "Geography trainee from 2024/25",
+    classes: "govuk-!-margin-bottom-5"
+) %>
+
 ## Available support
 Your training provider might offer services like careers advisers or mental health support. It's useful to be aware of what these are and how you can access them.
 

--- a/app/views/content/prepare-for-training/what-to-expect-from-your-teacher-training-provider.md
+++ b/app/views/content/prepare-for-training/what-to-expect-from-your-teacher-training-provider.md
@@ -38,7 +38,7 @@ If you’re doing a postgraduate certificate in education (PGCE) alongside quali
 These can sometimes come at the same time so it would be useful to know when these are so that you can plan and manage your time. For example, if you need to take into account things such as childcare.
 
 <%= render Cards::QuoteComponent.new(
-    text: "I think the biggest challenge was trying to balance my university work with the increasing teaching load.",
+    text: "I think the biggest challenge was trying to balance my university work with the increasing teaching load. I dealt with this my making a schedule that worked for me.",
     attribution: "Geography trainee from 2024/25",
     classes: "govuk-!-margin-bottom-5"
 ) %>

--- a/app/views/content/resources-while-training/behaviour-management.md
+++ b/app/views/content/resources-while-training/behaviour-management.md
@@ -28,6 +28,12 @@ Learning how to manage behaviour in a classroom will be a key part of your teach
 
 But don’t worry – your provider and placement schools will work together to teach you different techniques and practices and will be there to provide support and advice for any challenges you face.
 
+<%= render Cards::QuoteComponent.new(
+    text: "Balancing time management and behaviour management is essential. I prioritise establishing good behaviour first; once students are engaged, I can cover the lesson content efficiently and on schedule.",
+    attribution: "MFL trainee from 2024/25",
+    classes: "govuk-!-margin-bottom-5"
+) %>
+
 ## Things to consider
 Each school will have its own behaviour management policy so it’s important to check what your school has in place.
 
@@ -37,6 +43,12 @@ When you start your placement, you might want to consider if you know:
 - how to record and share good behaviour and achievements
 - how to report a behaviour incident and implement any sanctions for challenging behaviour – will you need access to any systems to do this?
 - if there are any children in your class with special educational needs or disabilities (SEND) or a behaviour support plan and how you will be expected to support them
+
+<%= render Cards::QuoteComponent.new(
+    text: "Managing younger pupils, who often needed boundaries and redirection, didn’t come naturally at first. I overcame this by observing seasoned teachers. I read, practised, and adapted.",
+    attribution: "Science trainee from 2024/25",
+    classes: "govuk-!-margin-bottom-5"
+) %>
 
 ## Behaviour management resources
 You can <%= govuk_link_to "read the Department for Education’s trainee teacher behavioural toolkit", "https://www.gov.uk/government/publications/initial-teacher-training-itt-core-content-framework/the-trainee-teacher-behavioural-toolkit-a-summary" %>.

--- a/app/views/content/resources-while-training/lesson-planning-as-a-trainee-teacher.md
+++ b/app/views/content/resources-while-training/lesson-planning-as-a-trainee-teacher.md
@@ -32,7 +32,7 @@ You'll likely be given templates to start with by your provider and they or your
 **You should check with your school and training provider what their requirements are.**
 
 <%= render Cards::QuoteComponent.new(
-    text: "Artificial intelligence (AI) became a big help when it came to planning activities. AI is not there to teach, it is there to help you teach.",
+    text: "“A quote I remember is 'it never gets easier, you just get better.'”",
     attribution: "PE trainee from 2024/25",
     classes: "govuk-!-margin-bottom-5"
 ) %>

--- a/app/views/content/resources-while-training/lesson-planning-as-a-trainee-teacher.md
+++ b/app/views/content/resources-while-training/lesson-planning-as-a-trainee-teacher.md
@@ -31,6 +31,12 @@ Your placement school or provider may provide you with supportive materials for 
 
 ### You should check with your school and training provider what their requirements are.
 
+<%= render Cards::QuoteComponent.new(
+    text: "Artificial intelligence (AI) became a big help when it came to planning activities. AI is not there to teach, it is there to help you teach.",
+    attribution: "PE trainee from 2024/25",
+    classes: "govuk-!-margin-bottom-5"
+) %>
+
 ## Use the national curriculum
 All lesson planning should consider the national curriculum. The national curriculum sets out the programmes of study and attainment targets for all subjects at all 4 key stages.
 
@@ -41,6 +47,12 @@ You might want to <%= govuk_link_to "read the national curriculum", "https://www
 To see how this works in practice, you could watch recorded lessons from other teachers, for example, from <%= govuk_link_to "Oak National Academy", "https://www.thenational.academy/teachers" %>.
 
 You can also look at your placement school’s website to understand what's covered on their specific curriculum and how they implement this.
+
+<%= render Cards::QuoteComponent.new(
+    text: "Early subject knowledge preparation can help out loads! Read the texts, textbooks, revision guides.",
+    attribution: "English trainee from 2024/25",
+    classes: "govuk-!-margin-bottom-5"
+) %>
 
 ## How lesson planning works
 An important part of lesson planning will be how you incorporate:
@@ -73,6 +85,12 @@ They’re designed to help you develop expertise in teaching a specific subject 
 As part of your teacher training, you may want to <%= govuk_link_to "find and join a subject association", "https://www.subjectassociations.org.uk/our-members/" %>. They provide access to resources and professional development.
 
 Some will provide access to free resources whereas some will require a membership fee.
+
+<%= render Cards::QuoteComponent.new(
+    text: "The Geographical Association was extremely helpful for me. It provided teaching tips and advice within my field.",
+    attribution: "Geography trainee from 2024/25",
+    classes: "govuk-!-margin-bottom-5"
+) %>
 
 ## Lesson planning resources
 ### The Chartered College of Teaching tips

--- a/app/views/content/resources-while-training/meeting-the-teachers-standards.md
+++ b/app/views/content/resources-while-training/meeting-the-teachers-standards.md
@@ -53,6 +53,12 @@ The following statements define the behaviour and attitudes which set the requir
 2. Teachers must have proper and professional regard for the ethos, policies and practices of the school in which they teach and maintain high standards in their own attendance and punctuality.
 3. Teachers must have an understanding of, and always act within, the statutory frameworks which set out their professional duties and responsibilities.
 
+<%= render Cards::QuoteComponent.new(
+    text: "Remember that professionalism is the key. Ensure that you make positive relationships with all staff on your placements and turn up everyday on time.",
+    attribution: "Geography trainee from 2024/25",
+    classes: "govuk-!-margin-bottom-5"
+) %>
+
 ## When you’ll be assessed and how
 You will not be assessed against the teachers’ standards until the end of your course.
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/gUV2mFId/491-add-trainee-quotes

### Context

I have used the quotes component to add quotes throughout the service pages to reflect the prototype. Also added spacing to the advice to trainee quotes so they don't touch when stacked on mobile.

### Changes proposed in this pull request

Most content pages have been edited slightly to include quotes within the content

### Guidance to review

Compare prototype with live service to ensure we have all quotes in the service we want and in the right position
