### PR TITLE
Fix issue with feedback form errors removing the page url

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,6 +1,7 @@
 class FeedbackController < ApplicationController
   before_action :set_frontmatter
 
+
   http_basic_authenticate_with(
     name: ENV["BASIC_AUTH_USERNAME"],
     password: ENV["BASIC_AUTH_PASSWORD"],
@@ -27,7 +28,6 @@ class FeedbackController < ApplicationController
 
   def create
     @feedback = Feedback.new(feedback_params)
-    @feedback.url = request.fullpath
 
     if @feedback.save
       flash = {
@@ -49,6 +49,6 @@ class FeedbackController < ApplicationController
   end
 
   def feedback_params
-    params.require(:feedback).permit(:rating, :topic, :description, :email, :can_contact)
+    params.require(:feedback).permit(:rating, :topic, :description, :email, :can_contact, :url)
   end
 end

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,7 +1,6 @@
 class FeedbackController < ApplicationController
   before_action :set_frontmatter
 
-
   http_basic_authenticate_with(
     name: ENV["BASIC_AUTH_USERNAME"],
     password: ENV["BASIC_AUTH_PASSWORD"],

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -14,5 +14,5 @@ class Feedback < ApplicationRecord
   validates :topic, presence: { message: "Select the area of the website relating to your feedback" }
   validates :url, url: { message: "Please enter a valid URL" }, if: -> { topic == "page" }
   validates :email, presence: { message: "Please enter a valid email" }, if: -> { can_contact }
-  validates :can_contact, presence: { message: "Please select a contact preference" }
+  validates :can_contact, inclusion: { in: [true, false], message: "Please select a contact preference" }
 end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -13,4 +13,6 @@ class Feedback < ApplicationRecord
   validates :rating, inclusion: { in: self.ratings.keys, message: "Select a rating from the list" }
   validates :topic, presence: { message: "Select the area of the website relating to your feedback" }
   validates :url, url: { message: "Please enter a valid URL" }, if: -> { topic == "page" }
+  validates :email, presence: { message: "Please enter a valid email" }, if: -> { can_contact }
+  validates :can_contact, presence: { message: "Please select a contact preference" }
 end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -14,5 +14,5 @@ class Feedback < ApplicationRecord
   validates :topic, presence: { message: "Select the area of the website relating to your feedback" }
   validates :url, url: { message: "Please enter a valid URL" }, if: -> { topic == "page" }
   validates :email, presence: { message: "Please enter a valid email" }, if: -> { can_contact }
-  validates :can_contact, inclusion: { in: [true, false], message: "Please select a contact preference" }
+  validates :can_contact, inclusion: { in: [ true, false ], message: "Please select a contact preference" }
 end

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -29,11 +29,11 @@
   %>
 
   <%= form.govuk_collection_radio_buttons :can_contact, 
-    ["Yes", "No"], 
+    [["Yes", true], ["No", false]], 
+    :last,
     :first,
-    ->(option) { option },
     ->(option) {
-      if option == "Yes"
+      if option.first == "Yes" 
         content_tag(:div, class: "hidden-subfield") do
           form.govuk_text_field(
             :email,

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -6,11 +6,11 @@
   } %>
 
   <%= form.govuk_collection_radio_buttons :topic, 
-    formatted_enum(:topics),
+    [["The whole site", "site"], ["A specific page", "page"]],
     :last,
     :first,
     ->(option) {
-      if option.first == "Page" 
+      if option.last == "page" 
         content_tag(:div, class: "hidden-subfield") do
           form.govuk_text_field(
             :url,
@@ -33,7 +33,7 @@
     :last,
     :first,
     ->(option) {
-      if option.first == "Yes" 
+      if option.last == true 
         content_tag(:div, class: "hidden-subfield") do
           form.govuk_text_field(
             :email,

--- a/spec/factories/feedback.rb
+++ b/spec/factories/feedback.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     rating { :satisfied }
     topic { :site }
     description { "Great!" }
+    can_contact { false }
 
     trait :with_contact_details do
       can_contact { true }

--- a/spec/helpers/feedback_helper_spec.rb
+++ b/spec/helpers/feedback_helper_spec.rb
@@ -15,17 +15,6 @@ RSpec.describe FeedbackHelper, type: :helper do
         ])
       end
     end
-
-    context ":topics" do
-      it "returns humanized enum keys with original keys" do
-        results = formatted_enum(:topics)
-
-        expect(results).to eq([
-          [ "Site", "site" ],
-          [ "Page", "page" ]
-        ])
-      end
-    end
   end
 
   describe "#humanized_boolean" do

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -100,5 +100,26 @@ RSpec.describe Feedback, type: :model do
         expect(feedback).to be_valid
       end
     end
+
+    context "when can_contact is true" do
+      let(:feedback) { build(:feedback, can_contact: true, email: email) }
+
+      context "and email is blank" do
+        let(:email) { nil }
+
+        it "is not valid" do
+          expect(feedback).to be_invalid
+          expect(feedback.errors[:email]).to include("Please enter a valid email")
+        end
+      end
+
+      context "and email is valid" do
+        let(:email) { "test@test.com" }
+
+        it "is valid" do
+          expect(feedback).to be_valid
+        end
+      end
+    end
   end
 end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -100,6 +100,15 @@ RSpec.describe Feedback, type: :model do
         expect(feedback).to be_valid
       end
     end
+    
+    context "when can_contact is missing" do
+      let(:feedback) { build(:feedback, can_contact: nil) }
+
+      it "is not valid" do
+        expect(feedback).to be_invalid
+        expect(feedback.errors[:can_contact]).to include("Please select a contact preference")
+      end
+    end
 
     context "when can_contact is true" do
       let(:feedback) { build(:feedback, can_contact: true, email: email) }

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Feedback, type: :model do
         expect(feedback).to be_valid
       end
     end
-    
+
     context "when can_contact is missing" do
       let(:feedback) { build(:feedback, can_contact: nil) }
 

--- a/spec/models/page_feedback_spec.rb
+++ b/spec/models/page_feedback_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe PageFeedback, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/oWHwbrNc/462-error-in-feedback-form-page-prepopulated-url

### Context

When coming to the feedback page from the "Give more feedback about this page" button on the page feedback widget, the page url is prepopulated. However, submitting this with an error (like not selecting a rating) causes the prepopulated url to be lost.

We need to fix this so that the page url persists in the form even if there is an error for the user.

### Changes proposed in this pull request

- Add conditional validations for `can_contact` and `email`

### Guidance to review

- Please try all permutations of this, with contact preferences, coming from another page so that it prepopulates the url, without email etc. Make sure error messages are as expected.