### PR TITLE
update service maintenance page footer

### DIFF
--- a/maintenance_page/html/index.html
+++ b/maintenance_page/html/index.html
@@ -120,7 +120,7 @@
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
             <h2 class="govuk-heading-m">Get help</h2>
             <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
-                <li>Email: <a class="govuk-link app-!-overflow-break-word govuk-footer__link" href="mailto:mailto:teacher.training@education.gov.uk">teacher.training@education.gov.uk</a></li>
+                <li>Email: <a class="govuk-link app-!-overflow-break-word govuk-footer__link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a></li>
                 <li>We aim to respond within 7 working days.</li>
               </ul>
           </div>

--- a/maintenance_page/html/index.html
+++ b/maintenance_page/html/index.html
@@ -119,17 +119,10 @@
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
             <h2 class="govuk-heading-m">Get help</h2>
-            <p class="govuk-body-s govuk-!-margin-bottom-1">
-              Call 0800 389 2500 or
-              <a
-                class="govuk-link govuk-footer__link"
-                href="https://getintoteaching.education.gov.uk/help-and-support?utm_source=apply-for-teacher-training.service.gov.uk&amp;utm_medium=referral&amp;utm_campaign=candidate_interface%2Fstart_page-create_account_or_sign_in&amp;utm_content=candidate_not_logged_in"
-                >chat online</a
-              >.
-            </p>
-            <p class="govuk-body-s govuk-!-margin-bottom-1">
-              Monday to Friday, 8:30am to 5:30pm (except public&nbsp;holidays)
-            </p>
+            <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
+                <li>Email: <a class="govuk-link app-!-overflow-break-word govuk-footer__link" href="mailto:mailto:teacher.training@education.gov.uk">teacher.training@education.gov.uk</a></li>
+                <li>We aim to respond within 7 working days.</li>
+              </ul>
           </div>
           <div class="govuk-footer__meta-item">
             <a


### PR DESCRIPTION
### Trello card

https://trello.com/c/ciAFk5qv/506-update-footer-text-and-links-in-service-maintenance-page

### Context

Small tweak to our service maintenance page as we noticed in the code we’re sending people to get into teaching instead of our own support e.g. bat or email. We’ve opted for email for now

### Changes proposed in this pull request

Small tweak to our service maintenance page as we noticed in the code we’re sending people to get into teaching instead of our own support e.g. bat or email. We’ve opted for email for now

### Guidance to review

if we can, load the maintenance page and check the footer 