### PR TITLE
changing to teacher.success@ to becomingateacher@digital.education.gov.uk

### DIFF
--- a/app/views/content/accessibility.md
+++ b/app/views/content/accessibility.md
@@ -32,7 +32,7 @@ We'll consider your request and get back to you in 7 days.
 
 ## Reporting accessibility problems with this website
 
-We're always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we're not meeting accessibility requirements, contact: <%= govuk_link_to "teacher.training@education.gov.uk", "mailto:teacher.training@education.gov.uk" %>.
+We're always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we're not meeting accessibility requirements, contact: <%= govuk_link_to "becomingateacher@digital.education.gov.uk", "mailto:becomingateacher@digital.education.gov.uk" %>.
 
 ## Enforcement procedure
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,4 @@
 en:
   service:
     name: Get ready to teach 
-    email: teacher.training@education.gov.uk
+    email: becomingateacher@digital.education.gov.uk


### PR DESCRIPTION
### Trello card

https://trello.com/c/dPeA7wE0/507-updating-any-reference-of-teacher-success-email-to-becomingateacherdigitaleducationgovuk-for-support-quieries

### Context

teacher.success@education.gov.uk email isn’t being used anymore, so replace with becomingateacher@digital.education.gov.uk. Did a search replace and only found 2 instances.

### Changes proposed in this pull request

teacher.success@education.gov.uk email isn’t being used anymore, so replace with becomingateacher@digital.education.gov.uk. Did a search replace and only found 2 instances.


### Guidance to review

check any support emails on accessibility page are bat 