### PR TITLE
adding get support mail to link to footer

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,5 +1,6 @@
 <%= govuk_footer(meta_items_title: "Helpful links", meta_items: [
   { text: "Feedback", href: "/feedback/new" },
+  { text: "Get support <span class='govuk-visually-hidden'>. This is a mail to link.</span>".html_safe, href: "mailto:becomingateacher@digital.education.gov.uk" },
   { text: "Privacy policy", href: "https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers" },
   { text: "Accessibility statement", href: "/accessibility" },
   { text: "Cookies policy", href: "/cookies" },

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_footer(meta_items_title: "Helpful links", meta_items: [
   { text: "Feedback", href: "/feedback/new" },
-  { text: "Get support <span class='govuk-visually-hidden'>. This is a mail to link.</span>".html_safe, href: "mailto:becomingateacher@digital.education.gov.uk" },
+  { text: "Get support <span class='govuk-visually-hidden'>. This is an email link.</span>".html_safe, href: "mailto:becomingateacher@digital.education.gov.uk" },
   { text: "Privacy policy", href: "https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers" },
   { text: "Accessibility statement", href: "/accessibility" },
   { text: "Cookies policy", href: "/cookies" },


### PR DESCRIPTION
### Trello card

### Context

adding get support mail to link to footer. also includes hidden text for screen readers.

### Changes proposed in this pull request

adding get support mail to link to footer. also includes hidden text for screen readers.

### Guidance to review

Look at get support footer link is working for mail to and voice over