### PR TITLE
Run applicaton as non-root user

### DIFF
--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -40,6 +40,8 @@ module "web_application" {
   replicas     = var.replicas
 
   send_traffic_to_maintenance_page = var.send_traffic_to_maintenance_page
+
+  run_as_non_root = true
 }
 
 module "worker_application" {
@@ -65,4 +67,6 @@ module "worker_application" {
   max_memory = var.worker_memory_max
 
   enable_logit = true
+
+  run_as_non_root = true
 }


### PR DESCRIPTION
## Context
Security improvement to run the application containers as a non-root user, addressing potential security vulnerabilities from running containers with root privileges.

##  Changes proposed in this pull request
Implement security hardening by configuring the application to run as a non-root user (UID 10001) instead of the default root user.

## Guidance to review
Testing in review app
/app $ ls -l | grep appuser
drwxr-xr-x    2 appuser  appgroup      4096 Aug 14 16:28 log
drwxr-xr-x    1 appuser  appgroup      4096 Aug 14 16:28 public
drwxr-xr-x    1 appuser  appgroup      4096 Aug 14 16:30 tmp

Verify file permissions
https://github.com/DFE-Digital/teacher-success/actions/runs/16969562595

## Link to Trello card
https://trello.com/c/2Bzck6EC/2436-security-aks-containers-run-as-non-root-user-ts-uptime
## Checklist
- [x]  Attach to Trello card
- [x]  Rebased main
- [x]  Cleaned commit history
- [x]  Tested by running locally