### PR TITLE
Unbold radio buttons

### DIFF
--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -18,7 +18,8 @@
           )
         end
       end
-    }, 
+    },
+    bold_labels: false,
     legend: { text: "Which area of the website is your feedback for?" }
   %>
 
@@ -42,7 +43,8 @@
           )
         end
       end
-    }, 
+    },
+    bold_labels: false,
     legend: { text: "Would you be interested in participating in future user research?" } 
   %>
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/ns0ZtabW/516-post-launch-bold-radio-buttons

### Context

- Un-boldening the radio buttons on the feedback page.

### Changes proposed in this pull request

- Add `bold_labels: false` to `govuk_collection_radio_buttons` so that the radio buttons aren't bold.

### Guidance to review

- Visit https://teach-pr-142.test.teacherservices.cloud/feedback/new
- Check that the radio buttons no longer appear in bold.


_Before_

<img width="538" height="172" alt="Screenshot 2025-09-02 at 10 12 38" src="https://github.com/user-attachments/assets/f7bf8fee-2c60-4454-9459-a8b5990a76dd" />

<img width="728" height="160" alt="Screenshot 2025-09-02 at 10 12 46" src="https://github.com/user-attachments/assets/7d1cb94a-acf8-4db3-8c69-f538efd59132" />


_After_

<img width="529" height="165" alt="Screenshot 2025-09-02 at 10 11 43" src="https://github.com/user-attachments/assets/a587a4e0-a55c-4809-9407-44523bed0690" />

<img width="716" height="161" alt="Screenshot 2025-09-02 at 10 11 50" src="https://github.com/user-attachments/assets/56c06ff2-5fc1-4121-a1a1-58a34edad89d" />



