### PR TITLE
Wrap cookies page in grid-column-two-third

### DIFF
--- a/app/views/cookie_preferences/edit.html.erb
+++ b/app/views/cookie_preferences/edit.html.erb
@@ -1,125 +1,128 @@
-<p>Cookies are small files saved on your phone, tablet or computer when you visit a website.</p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p>Cookies are small files saved on your phone, tablet or computer when you visit a website.</p>
 
-<p>We use strictly necessary cookies to make the service work. We also use additional cookies to measure how you use the service and to help us with our marketing and communications.</p>
+    <p>We use strictly necessary cookies to make the service work. We also use additional cookies to measure how you use the service and to help us with our marketing and communications.</p>
 
-<p>You can choose which Cookies you're happy for us to use.</p>
+    <p>You can choose which Cookies you're happy for us to use.</p>
 
-<h2>Essential Cookies</h2>
+    <h2>Essential Cookies</h2>
 
-<p>These essential cookies do things like store information about your time on the service and remember your cookie settings.</p>
+    <p>These essential cookies do things like store information about your time on the service and remember your cookie settings.</p>
 
-<table class="govuk-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header">Name</th>
-      <th scope="col" class="govuk-table__header">Purpose</th>
-      <th scope="col" class="govuk-table__header">Expires</th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">teach-preferences</td>
-      <td class="govuk-table__cell">Website cookie that stores your cookie preferences</td>
-      <td class="govuk-table__cell">90 days</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">teach_session</td>
-      <td class="govuk-table__cell">Stores encrypted information about your time on the service</td>
-      <td class="govuk-table__cell">When you close your browser</td>
-    </tr>
-  </tbody>
-</table>
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Name</th>
+          <th scope="col" class="govuk-table__header">Purpose</th>
+          <th scope="col" class="govuk-table__header">Expires</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">teach-preferences</td>
+          <td class="govuk-table__cell">Website cookie that stores your cookie preferences</td>
+          <td class="govuk-table__cell">90 days</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">teach_session</td>
+          <td class="govuk-table__cell">Stores encrypted information about your time on the service</td>
+          <td class="govuk-table__cell">When you close your browser</td>
+        </tr>
+      </tbody>
+    </table>
 
-<p>Essential cookies always need to be on.</p>
+    <p>Essential cookies always need to be on.</p>
 
-<h2>Additional analytics cookies</h2>
-<h3>Cookies that measure website use</h3>
+    <h2>Additional analytics cookies</h2>
+    <h3>Cookies that measure website use</h3>
 
-<p>We use cookies to measure how you use the service. These cookies collect information about:</p>
+    <p>We use cookies to measure how you use the service. These cookies collect information about:</p>
 
-<ul>
-  <li>the pages you visit</li>
-  <li>how long you spend on each page</li>
-  <li>how you got to the service</li>
-  <li>what you select while using the service</li>
-  <li>any errors you see while using the service</li>
-</ul>
+    <ul>
+      <li>the pages you visit</li>
+      <li>how long you spend on each page</li>
+      <li>how you got to the service</li>
+      <li>what you select while using the service</li>
+      <li>any errors you see while using the service</li>
+    </ul>
 
-<p>We anonymise any personally identifiable information, like your IP address or your postcode before we share it with Google.</p>
+    <p>We anonymise any personally identifiable information, like your IP address or your postcode before we share it with Google.</p>
 
-<table class="govuk-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header">Name</th>
-      <th scope="col" class="govuk-table__header">Purpose</th>
-      <th scope="col" class="govuk-table__header">Expires</th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">_ga</td>
-      <td class="govuk-table__cell">Used to distinguish anonymous users</td>
-      <td class="govuk-table__cell">2 years</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">_gid</td>
-      <td class="govuk-table__cell">Used to distinguish anonymous users</td>
-      <td class="govuk-table__cell">24 hours</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">_gat</td>
-      <td class="govuk-table__cell">Used to manage the rate at which page view requests are made</td>
-      <td class="govuk-table__cell">1 minute</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">_clck</td>
-      <td class="govuk-table__cell">Persists the Clarity User ID and preferences, unique to that site is attributed to the same user ID</td>
-      <td class="govuk-table__cell">12 months</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">_clsk</td>
-      <td class="govuk-table__cell">Connects multiple page views by a user into a single Clarity session recording</td>
-      <td class="govuk-table__cell">1 day</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">CLID</td>
-      <td class="govuk-table__cell">Identifies the first-time Clarity saw this user on any site using Clarity</td>
-      <td class="govuk-table__cell">12 months</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">ANONCHK</td>
-      <td class="govuk-table__cell">This cookie ensures that clicks from advertisement on the Bing search engine are verified and it is used for reporting purposes and for personalisation</td>
-      <td class="govuk-table__cell">10 minutes</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">MR</td>
-      <td class="govuk-table__cell">Indicates whether to refresh MUID</td>
-      <td class="govuk-table__cell">1 week</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">MUID</td>
-      <td class="govuk-table__cell">Identifies unique web browsers visiting Microsoft sites. These cookies are used for advertising, site analytics, and other operational purposes</td>
-      <td class="govuk-table__cell">13 months</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">SM</td>
-      <td class="govuk-table__cell">Used in synchronizing the MUID across Microsoft domains</td>
-      <td class="govuk-table__cell">13 months</td>
-    </tr>
-  </tbody>
-</table>
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Name</th>
+          <th scope="col" class="govuk-table__header">Purpose</th>
+          <th scope="col" class="govuk-table__header">Expires</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">_ga</td>
+          <td class="govuk-table__cell">Used to distinguish anonymous users</td>
+          <td class="govuk-table__cell">2 years</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">_gid</td>
+          <td class="govuk-table__cell">Used to distinguish anonymous users</td>
+          <td class="govuk-table__cell">24 hours</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">_gat</td>
+          <td class="govuk-table__cell">Used to manage the rate at which page view requests are made</td>
+          <td class="govuk-table__cell">1 minute</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">_clck</td>
+          <td class="govuk-table__cell">Persists the Clarity User ID and preferences, unique to that site is attributed to the same user ID</td>
+          <td class="govuk-table__cell">12 months</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">_clsk</td>
+          <td class="govuk-table__cell">Connects multiple page views by a user into a single Clarity session recording</td>
+          <td class="govuk-table__cell">1 day</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">CLID</td>
+          <td class="govuk-table__cell">Identifies the first-time Clarity saw this user on any site using Clarity</td>
+          <td class="govuk-table__cell">12 months</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">ANONCHK</td>
+          <td class="govuk-table__cell">This cookie ensures that clicks from advertisement on the Bing search engine are verified and it is used for reporting purposes and for personalisation</td>
+          <td class="govuk-table__cell">10 minutes</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">MR</td>
+          <td class="govuk-table__cell">Indicates whether to refresh MUID</td>
+          <td class="govuk-table__cell">1 week</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">MUID</td>
+          <td class="govuk-table__cell">Identifies unique web browsers visiting Microsoft sites. These cookies are used for advertising, site analytics, and other operational purposes</td>
+          <td class="govuk-table__cell">13 months</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">SM</td>
+          <td class="govuk-table__cell">Used in synchronizing the MUID across Microsoft domains</td>
+          <td class="govuk-table__cell">13 months</td>
+        </tr>
+      </tbody>
+    </table>
 
-<h2>Change your cookie preferences</h2>
+    <h2>Change your cookie preferences</h2>
 
-<%= form_with model: @preferences, url: cookie_preferences_path, method: :patch do |form| %>
-  <%= form.govuk_collection_radio_buttons :non_essential, 
-    [["Yes", "true"], ["No", "false"]], 
-    :last, 
-    :first, 
-    legend: { 
-      text: "Allow tracking and performance cookies?" 
-  } %>
+    <%= form_with model: @preferences, url: cookie_preferences_path, method: :patch do |form| %>
+      <%= form.govuk_collection_radio_buttons :non_essential,
+        [["Yes", "true"], ["No", "false"]],
+        :last,
+        :first,
+        legend: {
+          text: "Allow tracking and performance cookies?"
+      } %>
 
-  <%= form.govuk_submit "Update cookie preferences" %>
-<% end %>
-
+      <%= form.govuk_submit "Update cookie preferences" %>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
### Trello card

- https://trello.com/c/4lXN52oC/536-cookies-policy-table

### Context

- Wrap cookies page in `grid-column-two-third` so that the content only stretches across 75% of the page.

### Changes proposed in this pull request

- Add `<div>` elements with classes `govuk-grid-row` and `govuk-grid-column-two-thirds` to wrap around the content on the cookies page.

### Guidance to review

Visit https://teach-pr-143.test.teacherservices.cloud/cookies
Check that the content on the page only reaches 75% of the page.

_Before_

<img width="1576" height="2844" alt="screencapture-localhost-3000-cookies-2025-09-02-16_21_11" src="https://github.com/user-attachments/assets/8b7f2ebe-de6d-49aa-ba4b-fea33527d61e" />

_After_

<img width="1576" height="2971" alt="screencapture-localhost-3000-cookies-2025-09-02-16_20_34" src="https://github.com/user-attachments/assets/a7120d3a-2117-4b8e-a83a-8276793fe9d0" />


