### PR TITLE
Fix indentation of dfe analytics config

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -1,19 +1,20 @@
 ---
 shared:
   :page_feedbacks:
-  - id
-  - useful
-  - feedback
-  - url
-  - created_at
-  - updated_at
+    - id
+    - useful
+    - feedback
+    - url
+    - created_at
+    - updated_at
   :feedbacks:
-  - id
-  - rating
-  - url
-  - description
-  - email
-  - topic
-  - can_contact
-  - created_at
-  - updated_at
+    - id
+    - rating
+    - url
+    - description
+    - email
+    - topic
+    - can_contact
+    - created_at
+    - updated_at
+


### PR DESCRIPTION
### Trello card

https://trello.com/c/CKM2b3J0/558-%F0%9F%90%9E-bug-user-feedback-and-page-feedback-is-not-being-sent-via-dfe-analytics

### Context

Page feedback and feedback models are not writing to bigquery, we're not sure why but it could be a misconfig

### Changes proposed in this pull request

Fix indentation for valid yaml, see if this helps

### Guidance to review

