### PR TITLE
Redirect everything to a service_closed page

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -16,4 +16,8 @@ class ErrorsController < ApplicationController
   def internal_server_error
     render "internal_server_error", status: :internal_server_error
   end
+
+  def service_closed
+    render "service_closed", status: :service_unavailable
+  end
 end

--- a/app/views/errors/service_closed.html.erb
+++ b/app/views/errors/service_closed.html.erb
@@ -1,0 +1,10 @@
+<%= content_for :page_title, "Sorry, this service is unavailable" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Sorry, this service is unavailable</h1>
+    <p class="govuk-body">
+      Visit <%= govuk_link_to "Get Into Teaching", "https://getintoteaching.education.gov.uk/" %> for information about starting a teaching career.
+    </p>
+  </div>
+</div>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_service_navigation(
   service_name: t("service.name"),
   service_url: root_path,
-  navigation_items: CONTENT_LOADER.navigation_items,
+  navigation_items: [],
   current_path: request.path 
 ) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,9 +34,9 @@ Rails.application.routes.draw do
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
-  # Keep this last to route any other paths to the show controller and render 404s if not found
-  get "/*slug", to: "content#show"
+  # all urls are routed to the service closed page
+  get "/*slug", to: redirect("/")
 
   # Root to home page
-  root to: "content#show", defaults: { slug: "home" }
+  root to: "errors#service_closed"
 end

--- a/spec/controllers/content_controller_spec.rb
+++ b/spec/controllers/content_controller_spec.rb
@@ -1,22 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe ContentController, type: :controller do
-  describe "GET #show" do
-    let(:slug) { "test" }
+  describe "#set_layout" do
     let(:front_matter) { {} }
-    let(:markdown_content) { "# Hello World" }
-
-    before do
-      allow(CONTENT_LOADER).to receive(:find_by_slug)
-        .with(slug)
-        .and_return([ front_matter, markdown_content ])
-    end
 
     context "when layout is specified in the front matter" do
       let(:front_matter) { { layout: "article" } }
 
       it "uses the layout specified in front matter" do
-        get :show, params: { slug: slug }
+        controller.instance_variable_set(:@front_matter, front_matter)
 
         expect(controller.send(:set_layout)).to eq("article")
       end
@@ -24,7 +16,7 @@ RSpec.describe ContentController, type: :controller do
 
     context "when layout is not specified" do
       it "defaults to application layout" do
-        get :show, params: { slug: slug }
+        controller.instance_variable_set(:@front_matter, front_matter)
 
         expect(controller.send(:set_layout)).to eq("application")
       end

--- a/spec/requests/content_spec.rb
+++ b/spec/requests/content_spec.rb
@@ -3,85 +3,28 @@ require 'rails_helper'
 
 RSpec.describe "Content Pages", type: :request do
   describe "GET /:slug" do
-    let(:slug) { "test" }
-    let(:front_matter) { {} }
-    let(:markdown_content) { '# Hello <%= "World" %>' }
+    it "redirects single-segment paths to the root page" do
+      get "/test"
 
-    before do
-      allow(CONTENT_LOADER).to receive(:find_by_slug)
-        .with(slug)
-        .and_return([ front_matter, markdown_content ])
+      expect(response).to redirect_to(root_path)
     end
 
-    it "renders the page content" do
-      get "/#{slug}"
+    it "redirects nested content paths to the root page" do
+      get "/prepare-for-training/timeline-of-your-training"
 
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to include("Hello World")
+      expect(response).to redirect_to(root_path)
     end
 
-    context "when the page has breadcrumbs" do
-      let(:front_matter) do
-        {
-          breadcrumbs: {
-            enable: true,
-            crumbs: [
-              {
-                name: "Breadcrumb 1", path: "/home"
-              },
-              {
-                name: "Breadcrumb 2",
-                path: "/help"
-              }
-            ]
-          }
-        }
-      end
-      let(:markdown_content) do
-        <<~MARKDOWN
-          ---
-            breadcrumbs:#{' '}
-                enable: true
-                crumbs:#{' '}
-                    - name: "Breadcrumb 1"
-                      path: "/home"
-                    - name: "Breadcrumb 2"
-                      path: "/help"
-          ---
-          # Hello <%= "World" %>
-        MARKDOWN
-      end
+    it "redirects missing paths to the root page" do
+      get "/missing-page"
 
-      before do
-        allow(CONTENT_LOADER).to receive(:find_by_slug)
-                                   .with(slug)
-                                   .and_return([ front_matter, markdown_content ])
-      end
-
-      it "renders te page content with breadcrumbs" do
-        get "/#{slug}"
-
-        expect(response).to have_http_status(:ok)
-        expect(response.body).to include("Hello World")
-        expect(response.body).to include("Breadcrumb 1")
-        expect(response.body).to include("Breadcrumb 2")
-      end
+      expect(response).to redirect_to(root_path)
     end
 
-    context "when the page is not found" do
-      let(:slug) { "missing-page" }
+    it "does not affect the root page" do
+      get root_path
 
-      before do
-        allow(CONTENT_LOADER).to receive(:find_by_slug)
-          .with(slug)
-          .and_raise(PageNotFoundError.new(slug))
-      end
-
-      it "redirects to the errors#not_found page" do
-        get "/#{slug}"
-
-        expect(response).to redirect_to(controller: "errors", action: "not_found")
-      end
+      expect(response).to have_http_status(:service_unavailable)
     end
   end
 end

--- a/spec/requests/cookie_preferences_spec.rb
+++ b/spec/requests/cookie_preferences_spec.rb
@@ -58,8 +58,7 @@ RSpec.describe "CookiePreferences", type: :request do
         it "sets the cookie with non_essential: true and redirects with success flash" do
           patch cookie_preferences_path, params: params, headers: headers
           expect(response).to redirect_to(root_path)
-          follow_redirect!
-          expect(response.body).to include("Your cookie preferences have been saved")
+          expect(flash[:success]).to include(heading: "Cookie preferences saved")
           expect(cookies[cookie_name]).to be_present
           cookie = JSON.parse(cookies[cookie_name])
           expect(cookie["non_essential"]).to eq(true)
@@ -72,8 +71,7 @@ RSpec.describe "CookiePreferences", type: :request do
         it "sets the cookie with non_essential: false" do
           patch cookie_preferences_path, params: params, headers: headers
           expect(response).to redirect_to(root_path)
-          follow_redirect!
-          expect(response.body).to include("Your cookie preferences have been saved")
+          expect(flash[:success]).to include(heading: "Cookie preferences saved")
           cookie = JSON.parse(cookies[cookie_name])
           expect(cookie["non_essential"]).to eq(false)
         end
@@ -112,8 +110,7 @@ RSpec.describe "CookiePreferences", type: :request do
         it "sets the cookie with non_essential: false" do
           patch cookie_preferences_path, params: params
           expect(response).to redirect_to(root_path)
-          follow_redirect!
-          expect(response.body).to include("Your cookie preferences have been saved")
+          expect(flash[:success]).to include(heading: "Cookie preferences saved")
           cookie = JSON.parse(cookies[cookie_name])
           expect(cookie["non_essential"]).to eq(false)
         end

--- a/spec/requests/page_feedback_spec.rb
+++ b/spec/requests/page_feedback_spec.rb
@@ -39,9 +39,7 @@ RSpec.describe "PageFeedbacks", type: :request do
         }.to change(PageFeedback, :count).by(1)
 
         expect(response).to redirect_to(root_path)
-        follow_redirect!
-
-        expect(response.body).to include("Feedback submitted")
+        expect(flash[:success]).to include(heading: "Feedback submitted")
       end
     end
   end

--- a/spec/system/cookie_banner_spec.rb
+++ b/spec/system/cookie_banner_spec.rb
@@ -59,9 +59,9 @@ RSpec.describe "Cookie Consent Banner", type: :system do
       expect(page).not_to have_selector(".govuk-cookie-banner", wait: 2)
     end
 
-    it "shows a flash notification" do
+    it "keeps users on the service closed page" do
       click_button "Accept additional cookies"
-      expect(page).to have_content("Your cookie preferences have been saved", wait: 2)
+      expect(page).to have_content("Sorry, this service is unavailable", wait: 2)
     end
 
     it "hides the banner on subsequent page loads" do
@@ -89,9 +89,9 @@ RSpec.describe "Cookie Consent Banner", type: :system do
       expect(page).not_to have_selector(".govuk-cookie-banner", wait: 2)
     end
 
-    it "shows a flash notification" do
-      click_button "Accept additional cookies"
-      expect(page).to have_content("Your cookie preferences have been saved", wait: 2)
+    it "keeps users on the service closed page" do
+      click_button "Reject additional cookies"
+      expect(page).to have_content("Sorry, this service is unavailable", wait: 2)
     end
 
     it "hides the banner on subsequent page loads" do


### PR DESCRIPTION
### Trello card
https://github.com/orgs/DFE-Digital/projects/101/views/6?pane=issue&itemId=206176296&issue=DFE-Digital%7Cclaim-issues%7C181

### Context
This service is now closed

### Changes proposed in this pull request
- Changed the root page to new service closed style error page
- Redirected all subpages to new service closed page as root page
